### PR TITLE
fixed a bug that returned a 404 when accessing the documentation on the browser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,13 +67,13 @@ endif
 
 npm-release: npm-login
 	
-ifeq ($(shell git describe --exact-match HEAD), )
+ifeq ($(shell git describe --exact-match HEAD 2>/dev/null), )
 	@echo "No tag is present for head, therefore not publishing to npm"
 else
-	echo "++++++++++++++++ Releasing to NPM +++++++++++++++++++++++++++++ "
-	echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+	@echo "++++++++++++++++ Releasing to NPM +++++++++++++++++++++++++++++ "
+	@echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
 	npm publish
-	rm .npmrc
+	rm ~/.npmrc
 endif
 	
 #Docker release module: Run docker release which will build docker container and push into whichever dockerhub  account you're logged into.

--- a/src/routes.js
+++ b/src/routes.js
@@ -20,7 +20,7 @@ module.exports = function() {
 			path: "/site/{fileName*}",
 			handler: {
 				directory: {
-					path: './site',
+					path: __dirname + '/../site',
 					listing: false,
 					index: true
 				}


### PR DESCRIPTION
The problem here was that when a user executes the tdctl script outside of the testdoubles directory, it would map the route to the current directory, which did not have the site folder, and thus returned a 404 error.
